### PR TITLE
feat: Relationクラスをパッケージから公開

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,27 @@
 import Model from './Model'
-import {IIndexable, IRoute, IRouteWrapper, IModel, Dictionary} from './interfaces'
+import {
+  IIndexable,
+  IRoute,
+  IRouteWrapper,
+  IModel,
+  Dictionary,
+} from './interfaces'
 import {ArrayMappable} from './entities/ArrayMappable'
 import {Paginate} from './entities/Paginate'
-import { RouteWrapper } from './entities/RouteWrapper'
-import { PaginateConfig } from './interfaces/PaginateConfig'
+import {RouteWrapper} from './entities/RouteWrapper'
+import {PaginateConfig} from './interfaces/PaginateConfig'
+import {Relation} from './Relation'
 
 export {
-	Model,
-	ArrayMappable,
-	Paginate,
-	PaginateConfig,
-	IIndexable,
-	IRouteWrapper,
-	IRoute,
-	IModel,
-	Dictionary,
-	RouteWrapper,
+  Model,
+  ArrayMappable,
+  Paginate,
+  PaginateConfig,
+  IIndexable,
+  IRouteWrapper,
+  IRoute,
+  IModel,
+  Dictionary,
+  RouteWrapper,
+  Relation,
 }


### PR DESCRIPTION
## 変更内容\n\n- Relationクラスをパッケージから公開するようにを修正\n- コードフォーマットの改善（インポート文の整理、インデントの調整）\n- CIのNode.jsバージョンを18.xのみに変更\n\n## 変更理由\n\n- Relationクラスを外部から利用できるようにするため\n- コードの可読性向上のため\n- Node.jsのバージョン管理の簡素化のため